### PR TITLE
Improvement blog card dark mode text #41

### DIFF
--- a/frontend/src/components/Shared/PostCardTitle.tsx
+++ b/frontend/src/components/Shared/PostCardTitle.tsx
@@ -63,9 +63,9 @@ export default function PostCardTitle({ postTitle, numVotes, numMinutes, numComm
           <TypeBadge type={postUser.type} size="small"></TypeBadge>
         </div>
         <div className="col-start-5 col-span-8 flex justify-between items-center">
-          <p className="text-gray-600 text-xs">• {numVotes} votos</p>
-          <p className="text-gray-600 text-xs">• {numComments} comentários</p>
-          <p className="text-gray-600 text-xs">• {dateText}</p>
+          <p className="text-gray-600 text-xs dark:text-zinc-400">• {numVotes} votos</p>
+          <p className="text-gray-600 text-xs dark:text-zinc-400">• {numComments} comentários</p>
+          <p className="text-gray-600 text-xs dark:text-zinc-400">• {dateText}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Improvement of blog card on dark mode. clearer text to see.

![image](https://github.com/user-attachments/assets/07b1f0ae-45b3-4e03-b98e-7c47e8af9182)
